### PR TITLE
Allow dirtyProperties to be overridden.

### DIFF
--- a/test/rest-model-2-test.js
+++ b/test/rest-model-2-test.js
@@ -64,6 +64,22 @@ describe('RestModel.V2', function() {
         post.get('dirtyProperties').should.eql(['tags']);
       });
     });
+
+    context('when getDirtyProperties is overridden', function() {
+      it('uses that functionality', function() {
+        post.reopen({
+          getDirtyProperties: function() {
+            var current  = this.get('name.foo.bar');
+            var original = this.get('originalPropeties.name.foo.bar');
+            console.log(current, original);
+            return current === original ? [] : ['name'];
+          }
+        });
+        post.get('dirtyProperties').should.eql([]);
+        post.set('name', { foo: { bar: 'baz' }});
+        post.get('dirtyProperties').should.eql(['name']);
+      });
+    });
   });
 
   describe('.isClean', function() {


### PR DESCRIPTION
On another project, I needed to customize the functionality of 'dirtyProperties' to check nested object properties. However, the only way to do that was to completely redefine the `init` method. This pull request makes it a little easier. If you need custom functionality, just redefine `getDirtyProperties`.

This is mostly just a method extraction, with a bonus of a cleaner initializer. There aren't any changes in functionality.