### PR TITLE
'primaryKey' no longer volatile; defined during init.

### DIFF
--- a/test/rest-model-2-test.js
+++ b/test/rest-model-2-test.js
@@ -116,6 +116,14 @@ describe('RestModel.V2', function() {
         post.get('isNew').should.be.false;
       });
     });
+
+    context('when the primary key changes', function() {
+      it('should not use previously cached value', function() {
+        post.get('isNew').should.be.true;
+        post.set('id', 2);
+        post.get('isNew').should.be.false;
+      });
+    });
   });
 
   describe('path', function() {
@@ -261,7 +269,7 @@ describe('RestModel.V2', function() {
 
 
       it('fetches the record with the instance path', function() {
-        args[0].url.should.eql(post.get('path'));
+        args[0].url.should.eql('/posts/1');
       });
 
       it('fetches the record with the a GET', function() {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -11,7 +11,7 @@ before(function(done) {
   benv.setup(function() {
     global.jQuery       = require('../bower_components/jquery/dist/jquery.min.js');
     global.$            = jQuery;
-    global.Handlebars   = benv.require('../bower_components/handlebars/handlebars.min.js', 'Handlebars');
+    global.Handlebars   = benv.require('../bower_components/handlebars/handlebars.min.js');
     global.Ember        = benv.require('../bower_components/ember/ember.js', 'Ember');
     global.localStorage = {
       _cache: {},


### PR DESCRIPTION
Currently, properties that are dependent on 'primaryKey' must be flagged as volatile, otherwise they are incorrectly cached. Namely, 'isNew' and 'isPersisted' are being inappropriately cached (I've added a test for this). One solution would be to mark those as 'volatile' as well, but that would force client implementations that were dependent on any of those properties to also be flagged as 'volatile'.

I think the more appropriate solution is what you have listed in your TODO comments: define the 'primaryKey' and set it's dependencies during initialization. That's what this does.

