### PR TITLE
Primary key property is not retained after `fetch`

### DIFF
--- a/test/rest-model-2-test.js
+++ b/test/rest-model-2-test.js
@@ -304,6 +304,12 @@ describe('RestModel.V2', function() {
           post.get('name').should.eql('Test Post');
         });
       });
+
+      it('still knows how to build a path', function() {
+        return post.fetch().then(function() {
+          post.get('path').should.eql('/posts/1');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
[v1.7.1](https://github.com/jclem/rest-model/commit/52ce0fb8274f15770b7d0402a594760c0d3dd843) has introduced a bug in Model v2 where a second call to `fetch()` on a model will not grab the primary key when building a URL. This means (generally) that whilst the first call will `GET /resource/:an_id` the second call will `GET /resource` and end up replacing the model with an index array.

I'm pretty sure the cause is [here](https://github.com/jclem/rest-model/commit/ff037ee094e6d7a416d851442611aa98d78e3f1a#diff-bc2fb540b1fd7093ffbaa38f0bc8da67R391), but I don't want to remove or revert as I'm not sure about the reason for adding it initially.

@joshwlewis @JackCA do you have any thoughts on this?