### PR TITLE
Support setProperties() with primaryKey during fetch.

### DIFF
--- a/index-v2.js
+++ b/index-v2.js
@@ -379,17 +379,23 @@ module.exports = Ember.Object.extend({
    * @private
    */
   _definePrimaryKey: function() {
-    var args = this.constructor.primaryKeys.concat(function() {
+    var args = this.constructor.primaryKeys.concat(function(_, setValue) {
       var keyNames = this.constructor.primaryKeys;
-      var key, value;
+      if (setValue === undefined) {
+        var key, value;
+        for (var i = 0; i < keyNames.length; i++) {
+          key   = keyNames[i];
+          value = this.get(key);
 
-      for (var i = 0; i < keyNames.length; i++) {
-        key   = keyNames[i];
-        value = this.get(key);
-
-        if (!Ember.isNone(value)) {
-          return value;
+          if (!Ember.isNone(value)) {
+            return value;
+          }
         }
+      } else {
+        if (this.get('primaryKey') !== setValue) {
+          this.set(keyNames[0], setValue);
+        }
+        return setValue;
       }
     });
     var primaryKey = Ember.computed.apply(Ember, args);

--- a/test/rest-model-2-test.js
+++ b/test/rest-model-2-test.js
@@ -304,6 +304,12 @@ describe('RestModel.V2', function() {
           post.get('name').should.eql('Test Post');
         });
       });
+
+      it('still knows how to build a path', function() {
+        return post.fetch().then(function() {
+          post.get('path').should.eql('/posts/1');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This fixes #16. Which was indeed introduced by my #15.

Deep in the code, `#fetch` tries to update `primaryKey` (among every other attribute). This essentially was causing `primaryKey` to be cached as `null`. This change allows primaryKey to be set in a simple manner, and now caches the value correctly.

/cc @appleton @JackCA 