### PR TITLE
dirtyProperties should observe raw attributes.

### DIFF
--- a/index-v2.js
+++ b/index-v2.js
@@ -409,7 +409,7 @@ module.exports = Ember.Object.extend({
    * @private
    */
   _defineDirtyProperties: function() {
-    var args = this.get('attrNames')
+    var args = this.get('attrs')
                    .concat('originalProperties', this.getDirtyProperties);
     var dirtyProperties = Ember.computed.apply(Ember, args);
     Ember.defineProperty(this, 'dirtyProperties', dirtyProperties);

--- a/test/rest-model-2-test.js
+++ b/test/rest-model-2-test.js
@@ -62,6 +62,8 @@ describe('RestModel.V2', function() {
       it('includes that property', function() {
         post.get('tags').pushObject('draft');
         post.get('dirtyProperties').should.eql(['tags']);
+        post.get('tags').removeObject('draft');
+        post.get('dirtyProperties').should.eql([]);
       });
     });
 


### PR DESCRIPTION
Found a small bug when you have setup a model with `attrs: ['tags.[]']` or something similar. Since `dirtyProperties` was observing `tags` rather than `tags.[]`, `dirtyProperties` would get cached on the first change, and not be recalculated for subsequent changes.