### PR TITLE
Fix V2 filters leak

### DIFF
--- a/index-v2.js
+++ b/index-v2.js
@@ -752,7 +752,7 @@ module.exports = Ember.Object.extend({
       }.bind(this));
 
       return MutatingArray.apply(content)
-        .set('filters', this.filters)
+        .set('filters', Ember.copy(this.filters))
         .runFilters();
     } else {
       return this.create(response).setProperties(parents);


### PR DESCRIPTION
by passing on the literal class-level `filters` object to an instance of an V2 class, those instances are never able to get GC'ed.

Essentially every single V2 model instance would be stuck in memory.

This passes in a copy of the `filters` content and should behave the same way but allow the objects to get cleaned up.