### PR TITLE
Allow custom storage to be defined.

### DIFF
--- a/lib/cache-storage.js
+++ b/lib/cache-storage.js
@@ -1,0 +1,22 @@
+function NullStorage() {
+  var noop = function(){};
+
+  this.getItem = noop;
+  this.setItem = noop;
+  this.removeItem = noop;
+  this.clear = noop;
+  this.key = noop;
+  this.length = 0;
+};
+
+module.exports.NullStorage = NullStorage;
+
+module.exports.get = function() {
+  try {
+    localStorage.setItem('_rest-model', true);
+    localStorage.removeItem('_rest-model', true);
+    return localStorage;
+  } catch (error) {
+    return new NullStorage();
+  }
+};

--- a/lib/cache-v2.js
+++ b/lib/cache-v2.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var cacheStorage = require('./cache-storage');
+
 /**
  * A set of functions responsible for managing RestModel's localStorage cache.
  *
@@ -25,6 +27,11 @@ module.exports = Ember.Object.extend({
       }
     }.bind(this));
   },
+
+  /**
+   * A cache storage interface. It defaults to localStorage.
+   */
+  storage: cacheStorage.get(),
 
   /**
    * Fetch the cached attributes of the given array of keys.
@@ -200,7 +207,7 @@ module.exports = Ember.Object.extend({
    */
   getItem: function(key) {
     return new Ember.RSVP.Promise(function(resolve) {
-      var value = localStorage.getItem(key) || null;
+      var value = this.storage.getItem(key) || null;
 
       try {
         value = JSON.parse(value);
@@ -209,7 +216,7 @@ module.exports = Ember.Object.extend({
       }
 
       resolve(value);
-    });
+    }.bind(this));
   },
 
   /**
@@ -260,9 +267,9 @@ module.exports = Ember.Object.extend({
         stringValue = JSON.stringify(value);
       }
 
-      localStorage.setItem(key, stringValue);
+      this.storage.setItem(key, stringValue);
       resolve(value);
-    });
+    }.bind(this));
   },
 
   /**
@@ -277,8 +284,8 @@ module.exports = Ember.Object.extend({
    */
   removeItem: function(key) {
     return new Ember.RSVP.Promise(function(resolve) {
-      localStorage.removeItem(key);
+      this.storage.removeItem(key);
       resolve();
-    });
+    }.bind(this));
   }
 });

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('./utils');
+var cacheStorage = require('./cache-storage');
 
 /**
  * A set of functions responsible for managing RestModel's localStorage cache.
@@ -17,9 +18,15 @@ var utils = require('./utils');
  * @return {Object,Array.String,Array.Object} a cached object or array
  */
 exports.get = function(key) {
-  var value = localStorage.getItem(key) || null;
+  var value = this.storage.getItem(key) || null;
   return JSON.parse(value);
 };
+
+/**
+ * Set the cache storage interface. It uses localStorage by default.
+ * @type {Object}
+ */
+exports.storage = cacheStorage.get();
 
 /**
  * Set a JSON value as a string in the cache.
@@ -31,7 +38,7 @@ exports.get = function(key) {
  */
 exports.set = function(key, value) {
   var stringValue = JSON.stringify(value);
-  return localStorage.setItem(key, stringValue);
+  return this.storage.setItem(key, stringValue);
 };
 
 /**

--- a/test/cache-storage-test.js
+++ b/test/cache-storage-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+require('./test-helper');
+
+var should = require('should');
+var shared = require('./shared');
+var CacheStorage = require('../lib/cache-storage');
+var cacheStorage;
+
+describe('RestModel.CacheStorage', function() {
+  describe('with localStorage support', function() {
+    beforeEach(function(){
+      cacheStorage = CacheStorage.get();
+    });
+
+    it('sets item', function() {
+      cacheStorage.setItem('message', 'Hello');
+      cacheStorage.getItem('message').should.eql('Hello');
+    });
+
+    it('removes item', function() {
+      cacheStorage.setItem('message', 'Hello');
+      cacheStorage.removeItem('message');
+      should(cacheStorage.getItem('message')).be.undefined;
+    });
+  });
+
+  describe('without localStorage support', function(){
+    beforeEach(function(){
+      global.localStorage = undefined;
+      cacheStorage = CacheStorage.get();
+    });
+
+    afterEach(function(){
+      global.localStorage = global._localStorage;
+    });
+
+    it('does not fail when reading values', function(){
+      should.doesNotThrow(function(){
+        cacheStorage.getItem('message');
+      });
+    });
+
+    it('sets storage to nullStorage', function(){
+      cacheStorage.constructor.should.be.eql(CacheStorage.NullStorage);
+    });
+
+    it('does not fail when writing values', function(){
+      should.doesNotThrow(function(){
+        cacheStorage.setItem('message');
+      });
+    });
+
+    it('does not fail when removing values', function(){
+      should.doesNotThrow(function(){
+        cacheStorage.removeItem('message');
+      });
+    });
+  });
+});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -5,40 +5,48 @@ require('should');
 var benv  = require('benv');
 var sinon = require('sinon');
 
+global._localStorage = {
+  _cache: {},
+
+  getItem: function(key) {
+    return this._cache[key];
+  },
+
+  setItem: function(key, value) {
+    this._cache[key] = value;
+    return value;
+  },
+
+  removeItem: function(key) {
+    delete this._cache[key];
+  },
+
+  clear: function() {
+    this._cache = {};
+  }
+};
+
 global.context = describe;
+global.localStorage = _localStorage;
 
 before(function(done) {
   benv.setup(function() {
     global.jQuery       = require('../bower_components/jquery/dist/jquery.min.js');
     global.$            = jQuery;
     global.Handlebars   = benv.require('../bower_components/handlebars/handlebars.min.js');
-    global.Ember        = benv.require('../bower_components/ember/ember.js', 'Ember');
-    global.localStorage = {
-      _cache: {},
+    global.Ember        = benv.require('../bower_components/ember/ember.debug.js', 'Ember');
+    global.localStorage = _localStorage;
 
-      getItem: function(key) {
-        return this._cache[key];
-      },
-
-      setItem: function(key, value) {
-        this._cache[key] = value;
-        return value;
-      },
-
-      removeItem: function(key) {
-        delete this._cache[key];
-      },
-
-      clear: function() {
-        this._cache = {};
-      }
-    };
+    // Cache model with localStorage by loading it here.
+    require('./models');
+    localStorage.clear();
 
     done();
   });
 });
 
 beforeEach(function() {
+  global.localStorage = _localStorage;
   localStorage.clear();
 
   var self = this;


### PR DESCRIPTION
Safari doesn't allow using localStorage when opening private windows. So instead of assuming localStorage is available, we can workaround this issue by defining a custom interface when we don't have localStorage (unlikely) or we can't write to it (possible).