### PR TITLE
Relax ember dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "test"
   ],
   "dependencies": {
-    "ember": ">= 1.5.0 < 1.11"
+    "ember": ">= 1.5.0 < 1.13"
   },
   "devDependencies": {
     "handlebars": "~2.0.0"


### PR DESCRIPTION
The patch in #28 made rest-model work with (slightly) newer versions of Ember. Since Ember 1.10 is affected by [CVE-2015-7565](https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY), it'd be nice to be able to use `rest-model` with newer versions without a workaround.
